### PR TITLE
chore: unwrap the hard-wrapped authored text

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ pnpm build        # static output in dist/
 pnpm exec astro check
 ```
 
-`astro check` needs TypeScript 6.x. TypeScript 7's native compiler does not yet
-expose the programmatic API the checker uses, so `typescript` is pinned to `^6`.
+`astro check` needs TypeScript 6.x. TypeScript 7's native compiler does not yet expose the programmatic API the checker uses, so `typescript` is pinned to `^6`.
 
 ## Layout
 
@@ -27,13 +26,8 @@ expose the programmatic API the checker uses, so `typescript` is pinned to `^6`.
 
 ## Theming
 
-Colours are CSS custom properties on `:root`, redefined under
-`@media (prefers-color-scheme: dark)`, and exposed to Tailwind through
-`@theme inline`. To add a colour, define it in both blocks and map it once in
-`@theme inline`.
+Colours are CSS custom properties on `:root`, redefined under `@media (prefers-color-scheme: dark)`, and exposed to Tailwind through `@theme inline`. To add a colour, define it in both blocks and map it once in `@theme inline`.
 
 ## Adding a post
 
-Drop an `.mdx` file in `src/content/writing/`. Frontmatter needs `title`,
-`description`, `pubDate` and `topic`. Optional: `archiveNote` for pieces kept
-as a period record, and `draft: true` to hide it.
+Drop an `.mdx` file in `src/content/writing/`. Frontmatter needs `title`, `description`, `pubDate` and `topic`. Optional: `archiveNote` for pieces kept as a period record, and `draft: true` to hide it.

--- a/src/content/projects/bluehex.mdx
+++ b/src/content/projects/bluehex.mdx
@@ -11,53 +11,24 @@ lede: "An open-source directory built inside the Code.Sydney developer community
 
 ## What it is
 
-A directory for finding and hiring Claude and Anthropic practitioners. Anyone in
-the community can publish a profile, and Bluehex verifies the credentials behind
-it, which is the part that makes it worth reading. It came out of Code.Sydney, a
-volunteer developer community in Sydney, and it is open source. I look after the
-application and the website.
+A directory for finding and hiring Claude and Anthropic practitioners. Anyone in the community can publish a profile, and Bluehex verifies the credentials behind it, which is the part that makes it worth reading. It came out of Code.Sydney, a volunteer developer community in Sydney, and it is open source. I look after the application and the website.
 
 ## Why it is the interesting one
 
-The other projects here are single-author. This one is not, and that changes
-what the job is.
+The other projects here are single-author. This one is not, and that changes what the job is.
 
-Six outside contributors across three continents landed merged work in the first
-two weeks. Most of them found the repository cold and shipped without any direct
-onboarding from me, which is the actual test of whether the contribution surface
-works: not whether a contributor can be walked through it, but whether they can
-succeed without being walked through it.
+Six outside contributors across three continents landed merged work in the first two weeks. Most of them found the repository cold and shipped without any direct onboarding from me, which is the actual test of whether the contribution surface works: not whether a contributor can be walked through it, but whether they can succeed without being walked through it.
 
-So most of my effort goes into the things that make that possible. Issues are
-scoped to contributor experience level and labelled with a taxonomy that says
-what area they touch, roughly how big they are, and whether they suit a
-human-in-the-loop or an autonomous agent workflow. There is a contributing
-guide, an agent instructions file, issue and pull request templates, decision
-records and specs.
+So most of my effort goes into the things that make that possible. Issues are scoped to contributor experience level and labelled with a taxonomy that says what area they touch, roughly how big they are, and whether they suit a human-in-the-loop or an autonomous agent workflow. There is a contributing guide, an agent instructions file, issue and pull request templates, decision records and specs.
 
-Branch protection is real rather than nominal: the quality check is required and
-must be up to date with the base branch, reviews are dismissed when new commits
-land, and conversations have to be resolved before merge. The database policies
-are tested by running the real row-level security rules against a live Supabase
-stack rather than by asserting on mocks.
+Branch protection is real rather than nominal: the quality check is required and must be up to date with the base branch, reviews are dismissed when new commits land, and conversations have to be resolved before merge. The database policies are tested by running the real row-level security rules against a live Supabase stack rather than by asserting on mocks.
 
 ## A thing I caught in my own work
 
-A permissions endpoint was returning the wrong error. A database trigger was
-firing ahead of the row-level security check, so an unauthorised write came back
-as a constraint violation and an HTTP 400, when the honest answer was a
-permissions failure and an HTTP 403.
+A permissions endpoint was returning the wrong error. A database trigger was firing ahead of the row-level security check, so an unauthorised write came back as a constraint violation and an HTTP 400, when the honest answer was a permissions failure and an HTTP 403.
 
-The convenient fix was to raise the privileges of the function so the check ran
-earlier. I did not take it, and wrote down why: doing that would have turned
-something that currently discloses nothing into something that discloses whether
-a given record exists. The right fix was the slower one.
+The convenient fix was to raise the privileges of the function so the check ran earlier. I did not take it, and wrote down why: doing that would have turned something that currently discloses nothing into something that discloses whether a given record exists. The right fix was the slower one.
 
 ## What I am working on next
 
-The honest gap in this project is me. The infrastructure for contributors is
-good, and my reviews of their actual code are mostly a sentence of approval.
-Across every project on this site, the rigour is aimed inward, at my own work.
-Turning more of those approvals into real design conversations is the thing I am
-deliberately practising here, because it is the one skill in this set that
-cannot be practised alone.
+The honest gap in this project is me. The infrastructure for contributors is good, and my reviews of their actual code are mostly a sentence of approval. Across every project on this site, the rigour is aimed inward, at my own work. Turning more of those approvals into real design conversations is the thing I am deliberately practising here, because it is the one skill in this set that cannot be practised alone.

--- a/src/content/projects/latchkey.mdx
+++ b/src/content/projects/latchkey.mdx
@@ -11,58 +11,30 @@ lede: "A residential tenancy modelled as an append-only log, complete and tamper
 
 ## The problem it takes seriously
 
-I spent about four years in residential property management, as a property
-officer and then a property manager, before I became an engineer. So the domain
-here is not researched, it is remembered.
+I spent about four years in residential property management, as a property officer and then a property manager, before I became an engineer. So the domain here is not researched, it is remembered.
 
-The thing that stays with me is how often a tenancy dispute turns on what
-actually happened and when. Rent ledgers get adjusted. Notices get reissued.
-Somebody edits a record to correct a mistake and destroys the only evidence of
-what the mistake was. By the time a matter reaches a tribunal, the system of
-record can usually tell you the current state and cannot reliably tell you the
-history that produced it.
+The thing that stays with me is how often a tenancy dispute turns on what actually happened and when. Rent ledgers get adjusted. Notices get reissued. Somebody edits a record to correct a mistake and destroys the only evidence of what the mistake was. By the time a matter reaches a tribunal, the system of record can usually tell you the current state and cannot reliably tell you the history that produced it.
 
-That is a domain where event sourcing is not an architectural fashion. It is the
-shape of the problem.
+That is a domain where event sourcing is not an architectural fashion. It is the shape of the problem.
 
 ## How it is built
 
-The tenancy is reconstructed from an append-only event log rather than stored as
-mutable rows. State is a projection. Nothing is destroyed to record a
-correction, so the history that produced the current balance stays inspectable,
-and the log is complete enough to be used as evidence rather than as a
-convenience for the application.
+The tenancy is reconstructed from an append-only event log rather than stored as mutable rows. State is a projection. Nothing is destroyed to record a correction, so the history that produced the current balance stays inspectable, and the log is complete enough to be used as evidence rather than as a convenience for the application.
 
-The domain core is deliberately framework-free, sitting behind a Commanded
-shell, so the tenancy rules do not depend on the event-sourcing library that
-happens to carry them.
+The domain core is deliberately framework-free, sitting behind a Commanded shell, so the tenancy rules do not depend on the event-sourcing library that happens to carry them.
 
 ## The decision I am most pleased with
 
-Twelve architecture decision records, and the modules cite them by section, so a
-reader can get from a line of code to the reason it exists.
+Twelve architecture decision records, and the modules cite them by section, so a reader can get from a line of code to the reason it exists.
 
-The best of them splits the control plane from the data plane, and it is good
-because of how it is argued rather than what it concludes. It names one binding
-constraint, that a webhook arrives with no user present, derives a trilemma from
-that constraint, picks a two-tier resolution, and then closes with a consequences
-section that admits the resulting thin branch is not zero-touch. The cost is
-recorded next to the choice.
+The best of them splits the control plane from the data plane, and it is good because of how it is argued rather than what it concludes. It names one binding constraint, that a webhook arrives with no user present, derives a trilemma from that constraint, picks a two-tier resolution, and then closes with a consequences section that admits the resulting thin branch is not zero-touch. The cost is recorded next to the choice.
 
-There is a similar piece of care in the payments boundary, which splits
-retryable from non-retryable failures because the two have to drive checkpoint
-advancement differently. Getting that wrong either stalls the projection or
-silently skips an event.
+There is a similar piece of care in the payments boundary, which splits retryable from non-retryable failures because the two have to drive checkpoint advancement differently. Getting that wrong either stalls the projection or silently skips an event.
 
 ## How it is kept honest
 
-One alias runs the dependency audit, compilation with warnings as errors, the
-format check, strict linting, a security scan and coverage. The pre-push git
-hook runs that same alias, so the local gate and the CI gate cannot drift apart.
-Coverage is held at a floor of 85 percent across 51 test modules.
+One alias runs the dependency audit, compilation with warnings as errors, the format check, strict linting, a security scan and coverage. The pre-push git hook runs that same alias, so the local gate and the CI gate cannot drift apart. Coverage is held at a floor of 85 percent across 51 test modules.
 
 ## Status
 
-Parked. It was built as a study rather than a product, and it did what I wanted
-it to do: it taught me event sourcing and domain-driven design on a domain where
-I already knew which invariants were real and which ones were invented.
+Parked. It was built as a study rather than a product, and it did what I wanted it to do: it taught me event sourcing and domain-driven design on a domain where I already knew which invariants were real and which ones were invented.

--- a/src/content/projects/snag.mdx
+++ b/src/content/projects/snag.mdx
@@ -11,78 +11,38 @@ lede: "A tool for the failure modes that line-by-line review waves through. I cl
 
 ## What it did
 
-snag turned a spec, a PRD or a diff into a failure map: the happy path, then the
-ways it breaks. It borrowed FMEA, the failure-analysis discipline used in
-aerospace and manufacturing, and applied it to code review, on the argument that
-line-by-line review is good at finding defects in what is written and poor at
-finding what is missing.
+snag turned a spec, a PRD or a diff into a failure map: the happy path, then the ways it breaks. It borrowed FMEA, the failure-analysis discipline used in aerospace and manufacturing, and applied it to code review, on the argument that line-by-line review is good at finding defects in what is written and poor at finding what is missing.
 
-It ran as a skill inside a coding agent, driving that agent's read-only tools
-rather than shipping its own model calls. The CLI and renderer were open source
-under Apache 2.0 and published to npm. The Phoenix control plane behind them was
-not.
+It ran as a skill inside a coding agent, driving that agent's read-only tools rather than shipping its own model calls. The CLI and renderer were open source under Apache 2.0 and published to npm. The Phoenix control plane behind them was not.
 
 ## How it was tested
 
-Every claim was registered as an experiment before the work started, with a pass
-line and a fail line fixed in advance. The experiment documents carry a literal
-instruction at the top: frozen at proposed, do not edit once running.
+Every claim was registered as an experiment before the work started, with a pass line and a fail line fixed in advance. The experiment documents carry a literal instruction at the top: frozen at proposed, do not edit once running.
 
 ### The one that held
 
-The core claim was that automated failure-mode analysis finds faults a normal
-review misses. The criterion, set in advance: supported at roughly 70 percent
-recall or better, refuted below roughly 40 percent.
+The core claim was that automated failure-mode analysis finds faults a normal review misses. The criterion, set in advance: supported at roughly 70 percent recall or better, refuted below roughly 40 percent.
 
-Known failure modes were planted into clean subjects, and the mapper was run
-against the injected variant with no hint of where the fault was. The runs used
-subagents rather than forks, so nothing carried the answer key, and the clean
-twins acted as false-positive controls. Union recall came out at 14 of 14.
+Known failure modes were planted into clean subjects, and the mapper was run against the injected variant with no hint of where the fault was. The runs used subagents rather than forks, so nothing carried the answer key, and the clean twins acted as false-positive controls. Union recall came out at 14 of 14.
 
-The caveats I attached to that number matter more than the number. Recall was
-100 percent with three tries, not 100 percent every time. The bench skews toward
-faults that are catchable by construction. Precision was never scored.
+The caveats I attached to that number matter more than the number. Recall was 100 percent with three tries, not 100 percent every time. The bench skews toward faults that are catchable by construction. Precision was never scored.
 
 ### The two that did not
 
-A later experiment asked whether a failure map could be carried forward across
-code drift, which was already on the roadmap as a feature. It came back refuted:
-roughly 61 percent breakage across three subjects, and worse, roughly 80 percent
-of the drift carries were false. That produced an architecture decision record
-rather than a quiet edit to the plan.
+A later experiment asked whether a failure map could be carried forward across code drift, which was already on the roadmap as a feature. It came back refuted: roughly 61 percent breakage across three subjects, and worse, roughly 80 percent of the drift carries were false. That produced an architecture decision record rather than a quiet edit to the plan.
 
-The last experiment asked whether the graph representation actually beat flat
-findings for a reader. It was scored blind, with labels stripped, order shuffled
-and results joined mechanically on a key. At two of five subjects it was
-declared formally inconclusive, leaning null, rather than rounded up to a
-verdict.
+The last experiment asked whether the graph representation actually beat flat findings for a reader. It was scored blind, with labels stripped, order shuffled and results joined mechanically on a key. At two of five subjects it was declared formally inconclusive, leaning null, rather than rounded up to a verdict.
 
 ## Why I closed it
 
 That last result was the one that mattered, because the graph was the product.
 
-The kill document is dated 8 July 2026 and argues from a customer test rather
-than a mood. Four candidate readers for the artifact were tabulated. Three were
-already out of scope. The fourth was my own development flywheel, and I
-falsified that one from my own usage: the iteration that had found the product's
-weakness ran on flat markdown findings, a de-identify pass and a join script of
-about forty lines. No graph, no validation step, no ingest. The internal
-customer did not need it either.
+The kill document is dated 8 July 2026 and argues from a customer test rather than a mood. Four candidate readers for the artifact were tabulated. Three were already out of scope. The fourth was my own development flywheel, and I falsified that one from my own usage: the iteration that had found the product's weakness ran on flat markdown findings, a de-identify pass and a join script of about forty lines. No graph, no validation step, no ingest. The internal customer did not need it either.
 
-The shutdown was executed rather than declared. What stops and what survives
-were listed separately, a revive trigger was recorded, the twelfth experiment
-was marked cancelled rather than left pending, and a final release was cut with
-a pointer to where the post mortem lives.
+The shutdown was executed rather than declared. What stops and what survives were listed separately, a revive trigger was recorded, the twelfth experiment was marked cancelled rather than left pending, and a final release was cut with a pointer to where the post mortem lives.
 
-The held-out bench was then made public, precisely because there was no longer a
-live score to protect. It carries a warning that publishing contaminates it for
-any future blind measurement, so anyone wanting a live bench should plant fresh
-faults rather than reuse those.
+The held-out bench was then made public, precisely because there was no longer a live score to protect. It carries a warning that publishing contaminates it for any future blind measurement, so anyone wanting a live bench should plant fresh faults rather than reuse those.
 
 ## What I would do differently
 
-Precision went unscored for the whole life of the project. Every headline number
-is recall, which is the metric a generous automated judge inflates for free. The
-issues tracking precision and inter-rater agreement were open on the day I closed
-it. Every result here rests on a single rater, which is the load-bearing
-weakness in all of it.
+Precision went unscored for the whole life of the project. Every headline number is recall, which is the metric a generous automated judge inflates for free. The issues tracking precision and inter-rater agreement were open on the day I closed it. Every result here rests on a single rater, which is the load-bearing weakness in all of it.

--- a/src/content/projects/treetop.mdx
+++ b/src/content/projects/treetop.mdx
@@ -11,48 +11,26 @@ lede: "Every worktree, its branch, which ones have an agent session running, and
 
 ## Why it exists
 
-Running several coding agents at once produces a mess that git was never asked
-to solve. Worktrees accumulate across projects. Some have an agent working in
-them right now, some are waiting on CI, some are finished and forgotten. The
-information needed to tell those apart is spread across the filesystem, the git
-remote, the CI provider and whichever terminal the agent happens to be running
-in.
+Running several coding agents at once produces a mess that git was never asked to solve. Worktrees accumulate across projects. Some have an agent working in them right now, some are waiting on CI, some are finished and forgotten. The information needed to tell those apart is spread across the filesystem, the git remote, the CI provider and whichever terminal the agent happens to be running in.
 
-treetop puts it in one place, in the shape of `top`: a live view that refreshes
-rather than a report you run.
+treetop puts it in one place, in the shape of `top`: a live view that refreshes rather than a report you run.
 
 ## What it shows
 
-Every worktree on the machine, grouped by project, with its branch, whether an
-agent session is currently attached, and the status of the associated pull
-request and CI run, with links to open any of them. It understands both Claude
-Code and Codex sessions.
+Every worktree on the machine, grouped by project, with its branch, whether an agent session is currently attached, and the status of the associated pull request and CI run, with links to open any of them. It understands both Claude Code and Codex sessions.
 
 ## How it is built
 
-Go, as a terminal UI, with platform-specific session detection split by build
-tag so the Linux and macOS paths are separate files rather than branches inside
-one function.
+Go, as a terminal UI, with platform-specific session detection split by build tag so the Linux and macOS paths are separate files rather than branches inside one function.
 
-The part I would point at is the testing. There is a test file for essentially
-every source file in the project, which is unusual for a personal tool and was
-the point: it was built as a finishing exercise as much as a useful thing, and
-finishing includes the tests nobody sees.
+The part I would point at is the testing. There is a test file for essentially every source file in the project, which is unusual for a personal tool and was the point: it was built as a finishing exercise as much as a useful thing, and finishing includes the tests nobody sees.
 
 ## Status
 
-Shipped and complete. It is the project in this set that answers the question of
-whether I finish things, which is a fair question to ask of anyone whose other
-projects include two deliberate shutdowns.
+Shipped and complete. It is the project in this set that answers the question of whether I finish things, which is a fair question to ask of anyone whose other projects include two deliberate shutdowns.
 
 ## What I would do differently
 
-The CI does not run Go's race detector, and it should. There are goroutines in
-the file-watching path and a cache guarded by a mutex, which is exactly the
-shape of code where a race survives review and then shows up as an
-unreproducible hang. Adding the flag is a one-line change I have not made.
+The CI does not run Go's race detector, and it should. There are goroutines in the file-watching path and a cache guarded by a mutex, which is exactly the shape of code where a race survives review and then shows up as an unreproducible hang. Adding the flag is a one-line change I have not made.
 
-The repository also carries an agent instructions file prescribing a
-documentation structure that does not exist in the project. It is harmless but
-it is a stale instruction, and stale instructions are how agents get sent down
-paths that were abandoned.
+The repository also carries an agent instructions file prescribing a documentation structure that does not exist in the project. It is harmless but it is a stale instruction, and stale instructions are how agents get sent down paths that were abandoned.


### PR DESCRIPTION
Follow-up to #17. The four project entries and the README were hard-wrapped at roughly 80 columns; this unwraps them, so line breaks are left to real structure only — paragraphs, headings, list items, and code blocks.

## This is formatting only

Verified rather than asserted: built the site before and after, then compared every generated page with whitespace runs normalised.

```
IDENTICAL  ./index.html
IDENTICAL  ./projects/bluehex/index.html
IDENTICAL  ./projects/latchkey/index.html
IDENTICAL  ./projects/snag/index.html
IDENTICAL  ./projects/treetop/index.html
IDENTICAL  ./writing/index.html
IDENTICAL  ./writing/why-software-development/index.html
```

Not one word of the rendered output moves. The diff is large but there is nothing in it to read for meaning.

## What was left alone

- **`src/content/writing/why-software-development.mdx`** was already unwrapped, so it is untouched.
- **Frontmatter** in every entry passes through as-is.
- **The README table and its code fence** pass through as-is; only the three prose paragraphs around them changed.
- **`AGENTS.md`** was already unwrapped.
- **`src/content/projects/bilby.mdx`** is not here — it arrives unwrapped in #17, which this branch does not depend on.

Branched from `origin/main`, so this is independent of #17 and the two unpushed deploy commits on local `main`. Either can merge first.
