### PR TITLE
feat(bluehex): give Code.Sydney its own paragraph and a link

### DIFF
--- a/src/content/projects/bluehex.mdx
+++ b/src/content/projects/bluehex.mdx
@@ -11,7 +11,9 @@ lede: "An open-source directory built inside the Code.Sydney developer community
 
 ## What it is
 
-A directory for finding and hiring Claude and Anthropic practitioners. Anyone in the community can publish a profile, and Bluehex verifies the credentials behind it, which is the part that makes it worth reading. It came out of Code.Sydney, a volunteer developer community in Sydney, and it is open source. I look after the application and the website.
+A directory for finding and hiring Claude and Anthropic practitioners. Anyone in the community can publish a profile, and Bluehex verifies the credentials behind it, which is the part that makes it worth reading. It is open source, and I look after the application and the website.
+
+It came out of [Code.Sydney](https://code.sydney), a volunteer group of developers in Sydney who build and maintain real software for not-for-profits — Wundirra, the Parramatta Eisteddfod, PAMAI. The work is unpaid and the clients are organisations that could not otherwise afford a development team, which is a useful constraint: nothing ships because someone was paid to ship it.
 
 ## Why it is the interesting one
 


### PR DESCRIPTION
Code.Sydney was a subordinate clause in the middle of a sentence about something else, and it was not linked anywhere on the site. It is the reason this project exists and the reason it is the only multi-author entry here, so it gets a sentence of its own and a link to [code.sydney](https://code.sydney).

## What changed

The opening paragraph loses the clause, and Code.Sydney gets its own paragraph after it: the volunteer group, three of the not-for-profits it builds for, and the fact that the work is unpaid.

That last detail is the reason the paragraph is worth the space. The rest of the entry is about contributor infrastructure — the issue taxonomy, the contributing guide, the branch protection — and unpaid volunteers is what makes that infrastructure load-bearing rather than ceremonial. Nothing ships here because someone was paid to ship it.

## Checks

- The three organisations named are the ones listed on code.sydney, and "volunteer group of developers" is the site's own phrasing from a client testimonial, so the characterisation is not mine.
- First inline link in any content file; `.prose a` already styles it, and it renders as `<a href="https://code.sydney">Code.Sydney</a>`. `astro build` is clean.
- Rebased onto `main` after #18 merged, so this is a three-line diff against current `main`.

## Not done here

The metadata block on the project page still shows only Stack, Status and Source. If you would rather Code.Sydney appear there as its own row alongside the repo link, that needs a field on the projects schema, which felt like more than this change should decide on its own.
