### PR TITLE
fix(build): drop the empty pnpm workspace file that breaks the Cloudflare install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "portfolio",
   "type": "module",
+  "packageManager": "pnpm@10.22.0",
   "version": "0.0.1",
   "engines": {
     "node": ">=22.12.0"
@@ -17,9 +18,6 @@
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.2.9",
     "tailwindcss": "^4.3.3"
-  },
-  "allowScripts": {
-    "esbuild": true
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-allowBuilds:
-  esbuild: true
-  sharp: true


### PR DESCRIPTION
The Cloudflare build dies before it ever reaches Astro:

```
Installing project dependencies: pnpm install --frozen-lockfile
 ERROR  packages field missing or empty
Failed: error occurred while installing tools or dependencies
```

## Cause

`pnpm-workspace.yaml` declared only `allowBuilds` and no `packages` field. pnpm 10.4 and earlier reject that outright; 10.8 and later tolerate a settings-only workspace file. Reproduced against the exact `origin/main` tree:

| pnpm | `pnpm install --frozen-lockfile` |
| --- | --- |
| 10.0.0 | `ERROR packages field missing or empty` |
| 10.4.1 | `ERROR packages field missing or empty` |
| 10.8.1 | clean |
| 10.11.1 | clean |
| 10.12.4 | clean |

So the build log line `Detected the following tools from environment: pnpm@10.11.1` is reporting version *detection*, not the binary that ran the install — that one is older than 10.8. Worth knowing, because it means the detected-version line in those logs cannot be trusted as the version you are debugging against.

## Fix

**Deleted `pnpm-workspace.yaml`.** It was inert. Neither `allowBuilds` there nor `allowScripts` in `package.json` is a pnpm setting — which is why pnpm reports `Ignored build scripts: esbuild` with both of them in place. Removing them changes nothing about the install, and the site builds fine with esbuild's script ignored, because the platform binary arrives as its own package rather than through a postinstall. `allowScripts` is dropped from `package.json` for the same reason. If build scripts ever do need allowing, the real field is `pnpm.onlyBuiltDependencies`.

**Pinned `packageManager: "pnpm@10.22.0"`**, matching local, so the build image cannot silently pick an older pnpm than this repo's config again.

## Verification

- Workspace file removed, no pin: pnpm **10.0.0** installs cleanly on the frozen lockfile — so the deletion alone fixes it, and the pin is defence in depth.
- With the pin: **10.0.0, 10.4.1 and 10.11.1** all self-switch to 10.22.0 and install cleanly.
- `astro build` produces all 8 pages from the resulting tree.
- Lockfile untouched and still satisfies `--frozen-lockfile`.

## This does not finish the deploy

`wrangler.jsonc` is **not on `main`** — neither is the `wrangler` devDependency. Both live only in the two unpushed commits on your local `main` (`deploy: serve the static build from Cloudflare Workers`, `deploy: bind teeang.net to the Worker`). This PR gets the install past the error, but the Worker still has no configuration in the repository until those are pushed.
